### PR TITLE
ref(colorjson): modernize with any, b.Loop, and other minor enhancements

### DIFF
--- a/colorjson/README.md
+++ b/colorjson/README.md
@@ -39,7 +39,7 @@ str := `{
 }`
 
 // Create an intersting JSON object to marshal in a pretty format
-var obj map[string]interface{}
+var obj map[string]any
 json.Unmarshal([]byte(str), &obj)
 ```
 

--- a/colorjson/benchmarks/colorjson_test.go
+++ b/colorjson/benchmarks/colorjson_test.go
@@ -3,37 +3,30 @@ package colorjson_test
 import (
 	"testing"
 
-	"github.com/therootcompany/golib/colorjson"
 	"github.com/hokaccha/go-prettyjson"
+	"github.com/therootcompany/golib/colorjson"
 )
 
-func benchmarkMarshall(i int, b *testing.B) {
-	simpleMap := make(map[string]interface{})
+func BenchmarkMarshall(b *testing.B) {
+	simpleMap := make(map[string]any)
 	simpleMap["a"] = 1
 	simpleMap["b"] = "bee"
 	simpleMap["c"] = [3]float64{1, 2, 3}
 	simpleMap["d"] = [3]string{"one", "two", "three"}
 
-	// run the Fib function b.N times
-	for n := 0; n < b.N; n++ {
-		colorjson.Marshal(simpleMap)
+	for b.Loop() {
+		_, _ = colorjson.Marshal(simpleMap)
 	}
 }
 
-func benchmarkPrettyJSON(i int, b *testing.B) {
-	simpleMap := make(map[string]interface{})
+func BenchmarkPrettyJSON(b *testing.B) {
+	simpleMap := make(map[string]any)
 	simpleMap["a"] = 1
 	simpleMap["b"] = "bee"
 	simpleMap["c"] = [3]float64{1, 2, 3}
 	simpleMap["d"] = [3]string{"one", "two", "three"}
 
-	// run the Fib function b.N times
-	for n := 0; n < b.N; n++ {
-		prettyjson.Marshal(simpleMap)
+	for b.Loop() {
+		_, _ = prettyjson.Marshal(simpleMap)
 	}
 }
-
-func BenchmarkMarshall(b *testing.B)     { benchmarkMarshall(100, b) }
-func BenchmarkMarshall1k(b *testing.B)   { benchmarkMarshall(1000, b) }
-func BenchmarkPrettyJSON(b *testing.B)   { benchmarkPrettyJSON(100, b) }
-func BenchmarkPrettyJSON1k(b *testing.B) { benchmarkPrettyJSON(1000, b) }

--- a/colorjson/colorjson.go
+++ b/colorjson/colorjson.go
@@ -67,13 +67,13 @@ func (f *Formatter) writeObjSep(buf *bytes.Buffer) {
 	}
 }
 
-func (f *Formatter) Marshal(jsonObj interface{}) ([]byte, error) {
+func (f *Formatter) Marshal(jsonObj any) ([]byte, error) {
 	buffer := bytes.Buffer{}
 	f.marshalValue(jsonObj, &buffer, initialDepth)
 	return buffer.Bytes(), nil
 }
 
-func (f *Formatter) marshalMap(m map[string]interface{}, buf *bytes.Buffer, depth int) {
+func (f *Formatter) marshalMap(m map[string]any, buf *bytes.Buffer, depth int) {
 	remaining := len(m)
 
 	if remaining == 0 {
@@ -109,7 +109,7 @@ func (f *Formatter) marshalMap(m map[string]interface{}, buf *bytes.Buffer, dept
 	buf.WriteString(endMap)
 }
 
-func (f *Formatter) marshalArray(a []interface{}, buf *bytes.Buffer, depth int) {
+func (f *Formatter) marshalArray(a []any, buf *bytes.Buffer, depth int) {
 	if len(a) == 0 {
 		buf.WriteString(emptyArray)
 		return
@@ -130,11 +130,11 @@ func (f *Formatter) marshalArray(a []interface{}, buf *bytes.Buffer, depth int) 
 	buf.WriteString(endArray)
 }
 
-func (f *Formatter) marshalValue(val interface{}, buf *bytes.Buffer, depth int) {
+func (f *Formatter) marshalValue(val any, buf *bytes.Buffer, depth int) {
 	switch v := val.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		f.marshalMap(v, buf, depth)
-	case []interface{}:
+	case []any:
 		f.marshalArray(v, buf, depth)
 	case string:
 		f.marshalString(v, buf)
@@ -163,6 +163,6 @@ func (f *Formatter) marshalString(str string, buf *bytes.Buffer) {
 }
 
 // Marshal JSON data with default options
-func Marshal(jsonObj interface{}) ([]byte, error) {
+func Marshal(jsonObj any) ([]byte, error) {
 	return NewFormatter().Marshal(jsonObj)
 }

--- a/colorjson/examples/indent/main.go
+++ b/colorjson/examples/indent/main.go
@@ -17,8 +17,8 @@ func main() {
       "obj": { "a": 1, "b": 2 }
     }`
 
-	var obj map[string]interface{}
-	json.Unmarshal([]byte(str), &obj)
+	var obj map[string]any
+	_ = json.Unmarshal([]byte(str), &obj)
 
 	// Make a custom formatter with indent set
 	f := colorjson.NewFormatter()

--- a/colorjson/examples/simple/main.go
+++ b/colorjson/examples/simple/main.go
@@ -17,8 +17,8 @@ func main() {
       "obj": { "a": 1, "b": 2 }
     }`
 
-	var obj map[string]interface{}
-	json.Unmarshal([]byte(str), &obj)
+	var obj map[string]any
+	_ = json.Unmarshal([]byte(str), &obj)
 
 	// Marshall the Colorized JSON
 	s, _ := colorjson.Marshal(obj)


### PR DESCRIPTION
- `interface{}` => `any`
- `for range b.N` => `for b.Loop`
- explicitly catch impossible errors