### PR TITLE
ref!(envauth): change Verify return from bool to error

### DIFF
--- a/auth/envauth/README.md
+++ b/auth/envauth/README.md
@@ -12,7 +12,7 @@ creds := envauth.BasicCredentials{
    Password: os.Getenv("BASIC_AUTH_PASSWORD"),
 }
 
-verified := creds.Verify("username", "password")
+err := creds.Verify("username", "password")
 ```
 
 ## Basic Credentials: Username + Password
@@ -44,12 +44,17 @@ func main() {
       Password: password,
    }
 
-   verified := creds.Verify("api", "secret")
-   if verified {
-      println("Authentication successful")
-   } else {
-      println("Authentication failed")
+   if err := creds.Verify("api", "secret"); err != nil {
+      switch err {
+      case envauth.ErrUnauthorized:
+         println("Authentication failed")
+      default:
+         panic(err)
+      }
+      os.Exit(1)
    }
+
+   println("Authentication successful")
 }
 ```
 
@@ -104,11 +109,16 @@ func main() {
       Iterations: iterations,
    }
 
-   verified := creds.Verify("api", "secret")
-   if verified {
-      println("Authentication successful")
-   } else {
-      println("Authentication failed")
+   if err := creds.Verify("api", "secret"); err != nil {
+      switch err {
+      case envauth.ErrUnauthorized:
+         println("Authentication failed")
+      default:
+         panic(err)
+      }
+      os.Exit(1)
    }
+
+   println("Authentication successful")
 }
 ```

--- a/auth/envauth/envauth_test.go
+++ b/auth/envauth/envauth_test.go
@@ -14,50 +14,50 @@ func TestBasicCredentials_Verify(t *testing.T) {
 		creds    BasicCredentials
 		username string
 		password string
-		want     bool
+		want     error
 	}{
 		{
 			name:     "empty username, correct password",
 			creds:    BasicCredentials{Username: "", Password: "secret"},
 			username: "",
 			password: "secret",
-			want:     true,
+			want:     nil,
 		},
 		{
 			name:     "correct username, correct password",
 			creds:    BasicCredentials{Username: "user", Password: "secret"},
 			username: "user",
 			password: "secret",
-			want:     true,
+			want:     nil,
 		},
 		{
 			name:     "incorrect username, correct password",
 			creds:    BasicCredentials{Username: "user", Password: "secret"},
 			username: "wrong",
 			password: "secret",
-			want:     false,
+			want:     ErrUnauthorized,
 		},
 		{
 			name:     "correct username, incorrect password",
 			creds:    BasicCredentials{Username: "user", Password: "secret"},
 			username: "user",
 			password: "wrong",
-			want:     false,
+			want:     ErrUnauthorized,
 		},
 		{
 			name:     "correct username, empty password",
 			creds:    BasicCredentials{Username: "user", Password: "secret"},
 			username: "user",
 			password: "",
-			want:     false,
+			want:     ErrUnauthorized,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.creds.Verify(tt.username, tt.password)
-			if got != tt.want {
-				t.Errorf("Verify(%q, %q) = %v; want %v", tt.username, tt.password, got, tt.want)
+			err := tt.creds.Verify(tt.username, tt.password)
+			if err != tt.want {
+				t.Errorf("Verify(%q, %q) = %v; want %v", tt.username, tt.password, err, tt.want)
 			}
 		})
 	}
@@ -78,57 +78,57 @@ func TestPBKDF2Credentials_Verify(t *testing.T) {
 		creds    PBKDF2Credentials
 		username string
 		password string
-		want     bool
+		want     error
 	}{
 		{
 			name:     "empty username, correct password",
 			creds:    PBKDF2Credentials{Username: "", DerivedKey: secretDigest, Salt: salt, Iterations: 1000},
 			username: "",
 			password: "secret",
-			want:     true,
+			want:     nil,
 		},
 		{
 			name:     "correct username, correct password",
 			creds:    PBKDF2Credentials{Username: "user", DerivedKey: secretDigest, Salt: salt, Iterations: 1000},
 			username: "user",
 			password: "secret",
-			want:     true,
+			want:     nil,
 		},
 		{
 			name:     "incorrect username, correct password",
 			creds:    PBKDF2Credentials{Username: "user", DerivedKey: secretDigest, Salt: salt, Iterations: 1000},
 			username: "wrong",
 			password: "secret",
-			want:     false,
+			want:     ErrUnauthorized,
 		},
 		{
 			name:     "correct username, incorrect password",
 			creds:    PBKDF2Credentials{Username: "user", DerivedKey: secretDigest, Salt: salt, Iterations: 1000},
 			username: "user",
 			password: "wrong",
-			want:     false,
+			want:     ErrUnauthorized,
 		},
 		{
 			name:     "correct username, empty password",
 			creds:    PBKDF2Credentials{Username: "user", DerivedKey: secretDigest, Salt: salt, Iterations: 1000},
 			username: "user",
 			password: "",
-			want:     false,
+			want:     ErrUnauthorized,
 		},
 		{
 			name:     "empty username, empty pre-computed digest",
 			creds:    PBKDF2Credentials{Username: "", DerivedKey: emptyDigest, Salt: salt, Iterations: 1000},
 			username: "",
 			password: "",
-			want:     false,
+			want:     ErrUnauthorized,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.creds.Verify(tt.username, tt.password)
-			if got != tt.want {
-				t.Errorf("Verify(%q, %q) = %v; want %v", tt.username, tt.password, got, tt.want)
+			err := tt.creds.Verify(tt.username, tt.password)
+			if err != tt.want {
+				t.Errorf("Verify(%q, %q) = %v; want %v", tt.username, tt.password, err, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
`envauth` is intended as a stepping stone.

Originally the idea was just to handle plaintext username and password, for which `bool` sufices - there are no other types of error.

However, then we added pbkdf2 which can have  the exceptional case of misconfigured parameters, which we simply ignored and returned `false`.

In working on the upcoming `csvauth`, thre is more potential for a true error, and even moreso in `pgauth` (just in the idea stage right now).

And, since this hasn't actually "shipped" into production anywhere, we're changing the Verify signature:

```
Verify (string, string) error
```

Also, just deleting the v1.0.0 tag to replace with v1.0.1 - as if v1.0.0 never happened (again, since this hasn't "shipped"). I thought about marking it v0.9.0 instead... but it's not very likely this will ever change again. It does exactly what it should now.