### PR TITLE
feat: auth/csvauth add support for api tokens

### DIFF
--- a/auth/csvauth/credentials.tsv
+++ b/auth/csvauth/credentials.tsv
@@ -3,6 +3,8 @@ service1	acme	aes-128-gcm	2z92DVgMF9Hn-GBy	i37kF34cwa64j3tmnrvlJ5ZSekWD-w		token
 service2	acme	plain		token2		token2
 service3	user3	pbkdf2 1000 16 SHA-256	DYdA9iz1EN81bESTXcSgUg	IzkeBCxRVmqybOBeAntfdA		token3
 service4	user4	bcrypt		$2a$12$HueMNxFGYIYtNNTySFW/Lu4vAMqpdcchBnJrW.VdYgP9xPQdITipu		token4
+token	api~vkdAIZ2O	aes-128-gcm	kRHkOnbVdKfxwWNo	wC7edBEuz5htfvaagBfRUOHc60g		api1
+token	api~b5ZF2sRQ	aes-128-gcm	GowoB3l3eDiE4bPI	rtXBX9QbdrochVlr1SG8UWGllao		api2
 login	user1	pbkdf2 1000 16 SHA-256	R-NgfDcY1A6L5a4jO89TNw	-Pe9o-NwYvF6M4tlCwhm_g		pass1
 login	user2	bcrypt		$2a$12$pad8UgUphO43PioF1JlSHOblRPdaX.ikTqjA8D1EfrcBiNGI9WQ/y		pass2
 login	user3	aes-128-gcm	YC0xno0-W9pWR6rK	D9CZFCtGGJecLpCv2Fk1I-wcXmN3		pass3


### PR DESCRIPTION
We've had service tokens for the ability to retrieve a saved value, but these are not to be used for login / verification.

This adds the ability to have multiple login-style tokens, even of the same name.

- also some doc cleanup
- also make string representation `"[redacted]"`
- other minor quality of life improvements