### PR TITLE
fix(http/androidsmsgateway): use observed 'phoneNumber' field

### DIFF
--- a/http/androidsmsgateway/csv_test.go
+++ b/http/androidsmsgateway/csv_test.go
@@ -98,8 +98,7 @@ func TestCSV_WebhookSent(t *testing.T) {
 		"id": "Ey6ECgOkVVFjz3CL48B8C",
 		"payload": {
 			"messageId": "msg-456",
-			"sender": "+1234567890",
-			"recipient": "+9998887777",
+			"phoneNumber": "+1234567890",
 			"simNumber": 1,
 			"partsCount": 1,
 			"sentAt": "2026-02-18T02:05:00.000+07:00"
@@ -113,8 +112,8 @@ func TestCSV_WebhookSent(t *testing.T) {
 	}
 
 	const (
-		wantHeader = "deviceId,event,id,messageId,partsCount,recipient,sender,simNumber,sentAt,webhookId"
-		wantRow    = "ffffffffceb0b1db0000018e937c815b,sms:sent,Ey6ECgOkVVFjz3CL48B8C,msg-456,1,+9998887777,+1234567890,1,2026-02-18T02:05:00+07:00,LreFUt-Z3sSq0JufY9uWB"
+		wantHeader = "deviceId,event,id,messageId,partsCount,phoneNumber,simNumber,sentAt,webhookId"
+		wantRow    = "ffffffffceb0b1db0000018e937c815b,sms:sent,Ey6ECgOkVVFjz3CL48B8C,msg-456,1,+1234567890,1,2026-02-18T02:05:00+07:00,LreFUt-Z3sSq0JufY9uWB"
 	)
 
 	header, row := csvLines(t, *got)
@@ -130,11 +129,8 @@ func TestCSV_WebhookSent(t *testing.T) {
 	if parsed.Payload.MessageID != got.Payload.MessageID {
 		t.Errorf("MessageID: got %q, want %q", parsed.Payload.MessageID, got.Payload.MessageID)
 	}
-	if parsed.Payload.Sender != got.Payload.Sender {
-		t.Errorf("Sender: got %q, want %q", parsed.Payload.Sender, got.Payload.Sender)
-	}
-	if parsed.Payload.Recipient != got.Payload.Recipient {
-		t.Errorf("Recipient: got %q, want %q", parsed.Payload.Recipient, got.Payload.Recipient)
+	if parsed.Payload.PhoneNumber != got.Payload.PhoneNumber {
+		t.Errorf("PhoneNumber: got %q, want %q", parsed.Payload.PhoneNumber, got.Payload.PhoneNumber)
 	}
 	if parsed.Payload.PartsCount != got.Payload.PartsCount {
 		t.Errorf("PartsCount: got %d, want %d", parsed.Payload.PartsCount, got.Payload.PartsCount)
@@ -151,8 +147,7 @@ func TestCSV_WebhookDelivered(t *testing.T) {
 		"id": "Ey6ECgOkVVFjz3CL48B8C",
 		"payload": {
 			"messageId": "msg-789",
-			"sender": "+1234567890",
-			"recipient": "+9998887777",
+			"phoneNumber": "+1234567890",
 			"simNumber": 1,
 			"deliveredAt": "2026-02-18T02:10:00.000+07:00"
 		},
@@ -165,8 +160,8 @@ func TestCSV_WebhookDelivered(t *testing.T) {
 	}
 
 	const (
-		wantHeader = "deviceId,event,id,deliveredAt,messageId,recipient,sender,simNumber,webhookId"
-		wantRow    = "ffffffffceb0b1db0000018e937c815b,sms:delivered,Ey6ECgOkVVFjz3CL48B8C,2026-02-18T02:10:00+07:00,msg-789,+9998887777,+1234567890,1,LreFUt-Z3sSq0JufY9uWB"
+		wantHeader = "deviceId,event,id,deliveredAt,messageId,phoneNumber,simNumber,webhookId"
+		wantRow    = "ffffffffceb0b1db0000018e937c815b,sms:delivered,Ey6ECgOkVVFjz3CL48B8C,2026-02-18T02:10:00+07:00,msg-789,+1234567890,1,LreFUt-Z3sSq0JufY9uWB"
 	)
 
 	header, row := csvLines(t, *got)
@@ -182,11 +177,8 @@ func TestCSV_WebhookDelivered(t *testing.T) {
 	if parsed.Payload.MessageID != got.Payload.MessageID {
 		t.Errorf("MessageID: got %q, want %q", parsed.Payload.MessageID, got.Payload.MessageID)
 	}
-	if parsed.Payload.Sender != got.Payload.Sender {
-		t.Errorf("Sender: got %q, want %q", parsed.Payload.Sender, got.Payload.Sender)
-	}
-	if parsed.Payload.Recipient != got.Payload.Recipient {
-		t.Errorf("Recipient: got %q, want %q", parsed.Payload.Recipient, got.Payload.Recipient)
+	if parsed.Payload.PhoneNumber != got.Payload.PhoneNumber {
+		t.Errorf("PhoneNumber: got %q, want %q", parsed.Payload.PhoneNumber, got.Payload.PhoneNumber)
 	}
 	if !parsed.Payload.DeliveredAt.Equal(got.Payload.DeliveredAt) {
 		t.Errorf("DeliveredAt: got %v, want %v", parsed.Payload.DeliveredAt, got.Payload.DeliveredAt)
@@ -200,8 +192,7 @@ func TestCSV_WebhookFailed(t *testing.T) {
 		"id": "Ey6ECgOkVVFjz3CL48B8C",
 		"payload": {
 			"messageId": "msg-000",
-			"sender": "+1234567890",
-			"recipient": "+4445556666",
+			"phoneNumber": "+1234567890",
 			"simNumber": 3,
 			"failedAt": "2026-02-18T02:15:00.000+07:00",
 			"reason": "Network error"
@@ -215,8 +206,8 @@ func TestCSV_WebhookFailed(t *testing.T) {
 	}
 
 	const (
-		wantHeader = "deviceId,event,id,failedAt,messageId,reason,recipient,sender,simNumber,webhookId"
-		wantRow    = "ffffffffceb0b1db0000018e937c815b,sms:failed,Ey6ECgOkVVFjz3CL48B8C,2026-02-18T02:15:00+07:00,msg-000,Network error,+4445556666,+1234567890,3,LreFUt-Z3sSq0JufY9uWB"
+		wantHeader = "deviceId,event,id,failedAt,messageId,reason,phoneNumber,simNumber,webhookId"
+		wantRow    = "ffffffffceb0b1db0000018e937c815b,sms:failed,Ey6ECgOkVVFjz3CL48B8C,2026-02-18T02:15:00+07:00,msg-000,Network error,+1234567890,3,LreFUt-Z3sSq0JufY9uWB"
 	)
 
 	header, row := csvLines(t, *got)

--- a/http/androidsmsgateway/webhooks.go
+++ b/http/androidsmsgateway/webhooks.go
@@ -41,12 +41,11 @@ func (w *WebhookSent) GetEvent() string {
 
 // WebhookSentPayload contains details about the sent SMS.
 type WebhookSentPayload struct {
-	MessageID  string    `json:"messageId"  csv:"messageId"`
-	PartsCount int       `json:"partsCount" csv:"partsCount"`
-	Recipient  string    `json:"recipient"  csv:"recipient"`
-	Sender     string    `json:"sender"     csv:"sender"`
-	SimNumber  int       `json:"simNumber"  csv:"simNumber"`
-	SentAt     time.Time `json:"sentAt"     csv:"sentAt"`
+	MessageID   string    `json:"messageId"  csv:"messageId"`
+	PartsCount  int       `json:"partsCount" csv:"partsCount"`
+	PhoneNumber string    `json:"phoneNumber"     csv:"phoneNumber"`
+	SimNumber   int       `json:"simNumber"  csv:"simNumber"`
+	SentAt      time.Time `json:"sentAt"     csv:"sentAt"`
 }
 
 // WebhookDelivered represents a webhook notification for an SMS delivered event.
@@ -69,8 +68,7 @@ func (w *WebhookDelivered) GetEvent() string {
 type WebhookDeliveredPayload struct {
 	DeliveredAt time.Time `json:"deliveredAt" csv:"deliveredAt"`
 	MessageID   string    `json:"messageId"   csv:"messageId"`
-	Recipient   string    `json:"recipient"   csv:"recipient"`
-	Sender      string    `json:"sender"      csv:"sender"`
+	PhoneNumber string    `json:"phoneNumber"      csv:"phoneNumber"`
 	SimNumber   int       `json:"simNumber"   csv:"simNumber"`
 }
 
@@ -117,12 +115,11 @@ func (w *WebhookDataReceived) GetEvent() string {
 
 // WebhookDataReceivedPayload contains details about the received binary SMS.
 type WebhookDataReceivedPayload struct {
-	Data       string    `json:"data"       csv:"data"`
-	MessageID  string    `json:"messageId"  csv:"messageId"`
-	ReceivedAt time.Time `json:"receivedAt" csv:"receivedAt"`
-	Recipient  string    `json:"recipient"  csv:"recipient"`
-	Sender     string    `json:"sender"     csv:"sender"`
-	SimNumber  int       `json:"simNumber"  csv:"simNumber"`
+	Data        string    `json:"data"       csv:"data"`
+	MessageID   string    `json:"messageId"  csv:"messageId"`
+	ReceivedAt  time.Time `json:"receivedAt" csv:"receivedAt"`
+	PhoneNumber string    `json:"phoneNumber"     csv:"phoneNumber"`
+	SimNumber   int       `json:"simNumber"  csv:"simNumber"`
 }
 
 // WebhookMMSReceived represents a webhook notification for an mms:received event.
@@ -146,8 +143,7 @@ type WebhookMMSReceivedPayload struct {
 	ContentClass  string    `json:"contentClass"  csv:"contentClass"`
 	MessageID     string    `json:"messageId"     csv:"messageId"`
 	ReceivedAt    time.Time `json:"receivedAt"    csv:"receivedAt"`
-	Recipient     string    `json:"recipient"     csv:"recipient"`
-	Sender        string    `json:"sender"        csv:"sender"`
+	PhoneNumber   string    `json:"phoneNumber"        csv:"phoneNumber"`
 	SimNumber     int       `json:"simNumber"     csv:"simNumber"`
 	Size          int       `json:"size"          csv:"size"`
 	Subject       string    `json:"subject"       csv:"subject"`
@@ -172,24 +168,23 @@ func (w *WebhookFailed) GetEvent() string {
 
 // WebhookFailedPayload contains details about the failed SMS.
 type WebhookFailedPayload struct {
-	FailedAt  time.Time `json:"failedAt"   csv:"failedAt"`
-	MessageID string    `json:"messageId"  csv:"messageId"`
-	Reason    string    `json:"reason"     csv:"reason"`
-	Recipient string    `json:"recipient"  csv:"recipient"`
-	Sender    string    `json:"sender"     csv:"sender"`
-	SimNumber int       `json:"simNumber"  csv:"simNumber"`
+	FailedAt    time.Time `json:"failedAt"   csv:"failedAt"`
+	MessageID   string    `json:"messageId"  csv:"messageId"`
+	Reason      string    `json:"reason"     csv:"reason"`
+	PhoneNumber string    `json:"phoneNumber"     csv:"phoneNumber"`
+	SimNumber   int       `json:"simNumber"  csv:"simNumber"`
 }
 
 // WebhookPing represents a system:ping webhook event.
 type WebhookPing struct {
-	DeviceID   string             `json:"deviceId"           csv:"deviceId"`
-	Event      string             `json:"event"              csv:"event"`
-	ID         string             `json:"id"                 csv:"id"`
-	Payload    WebhookPingPayload `json:"payload"            csv:",inline"`
-	WebhookID  string             `json:"webhookId"          csv:"webhookId"`
-	PingedAt   time.Time          `json:"pingedAt,omitempty" csv:"pingedAt"`
-	XSignature string             `json:"x-signature"        csv:"-"`
-	XTimestamp int64              `json:"x-timestamp"        csv:"-"`
+	DeviceID   string             `json:"deviceId"    csv:"deviceId"`
+	Event      string             `json:"event"       csv:"event"`
+	ID         string             `json:"id"          csv:"id"`
+	Payload    WebhookPingPayload `json:"payload"     csv:",inline"`
+	WebhookID  string             `json:"webhookId"   csv:"webhookId"`
+	PingedAt   time.Time          `json:"pingedAt"    csv:"pingedAt"`
+	XSignature string             `json:"x-signature" csv:"-"`
+	XTimestamp int64              `json:"x-timestamp" csv:"-"`
 }
 
 // GetEvent marks WebhookPing as part of the WebhookEvent interface.

--- a/http/androidsmsgateway/webhooks_test.go
+++ b/http/androidsmsgateway/webhooks_test.go
@@ -80,8 +80,7 @@ func TestDecode_SMSDataReceived(t *testing.T) {
 		"payload": {
 			"messageId": "abc123",
 			"data": "SGVsbG8gRGF0YSBXb3JsZCE=",
-			"sender": "6505551212",
-			"recipient": "+1234567890",
+			"phoneNumber": "+1234567890",
 			"simNumber": 1,
 			"receivedAt": "2024-06-22T15:46:11.000+07:00"
 		},
@@ -101,11 +100,8 @@ func TestDecode_SMSDataReceived(t *testing.T) {
 	if got.Payload.Data != "SGVsbG8gRGF0YSBXb3JsZCE=" {
 		t.Errorf("Data = %q, want SGVsbG8gRGF0YSBXb3JsZCE=", got.Payload.Data)
 	}
-	if got.Payload.Sender != "6505551212" {
-		t.Errorf("Sender = %q, want 6505551212", got.Payload.Sender)
-	}
-	if got.Payload.Recipient != "+1234567890" {
-		t.Errorf("Recipient = %q, want +1234567890", got.Payload.Recipient)
+	if got.Payload.PhoneNumber != "+1234567890" {
+		t.Errorf("PhoneNumber = %q, want +1234567890", got.Payload.PhoneNumber)
 	}
 	if got.Payload.SimNumber != 1 {
 		t.Errorf("SimNumber = %d, want 1", got.Payload.SimNumber)
@@ -123,8 +119,7 @@ func TestDecode_MMSReceived(t *testing.T) {
 		"id": "Ey6ECgOkVVFjz3CL48B8C",
 		"payload": {
 			"messageId": "mms_12345abcde",
-			"sender": "6505551212",
-			"recipient": "+1234567890",
+			"phoneNumber": "+1234567890",
 			"simNumber": 1,
 			"transactionId": "T1234567890ABC",
 			"subject": "Photo attachment",
@@ -145,11 +140,8 @@ func TestDecode_MMSReceived(t *testing.T) {
 	if got.Payload.MessageID != "mms_12345abcde" {
 		t.Errorf("MessageID = %q, want mms_12345abcde", got.Payload.MessageID)
 	}
-	if got.Payload.Sender != "6505551212" {
-		t.Errorf("Sender = %q, want 6505551212", got.Payload.Sender)
-	}
-	if got.Payload.Recipient != "+1234567890" {
-		t.Errorf("Recipient = %q, want +1234567890", got.Payload.Recipient)
+	if got.Payload.PhoneNumber != "+1234567890" {
+		t.Errorf("PhoneNumber = %q, want +1234567890", got.Payload.PhoneNumber)
 	}
 	if got.Payload.SimNumber != 1 {
 		t.Errorf("SimNumber = %d, want 1", got.Payload.SimNumber)
@@ -179,8 +171,7 @@ func TestDecode_SMSSent(t *testing.T) {
 		"id": "Ey6ECgOkVVFjz3CL48B8C",
 		"payload": {
 			"messageId": "msg-456",
-			"sender": "+1234567890",
-			"recipient": "+9998887777",
+			"phoneNumber": "+9998887777",
 			"simNumber": 1,
 			"partsCount": 1,
 			"sentAt": "2026-02-18T02:05:00.000+07:00"
@@ -198,11 +189,8 @@ func TestDecode_SMSSent(t *testing.T) {
 	if got.Payload.MessageID != "msg-456" {
 		t.Errorf("MessageID = %q, want msg-456", got.Payload.MessageID)
 	}
-	if got.Payload.Sender != "+1234567890" {
-		t.Errorf("Sender = %q, want +1234567890", got.Payload.Sender)
-	}
-	if got.Payload.Recipient != "+9998887777" {
-		t.Errorf("Recipient = %q, want +9998887777", got.Payload.Recipient)
+	if got.Payload.PhoneNumber != "+9998887777" {
+		t.Errorf("PhoneNumber = %q, want +9998887777", got.Payload.PhoneNumber)
 	}
 	if got.Payload.SimNumber != 1 {
 		t.Errorf("SimNumber = %d, want 1", got.Payload.SimNumber)
@@ -223,8 +211,7 @@ func TestDecode_SMSDelivered(t *testing.T) {
 		"id": "Ey6ECgOkVVFjz3CL48B8C",
 		"payload": {
 			"messageId": "msg-789",
-			"sender": "+1234567890",
-			"recipient": "+9998887777",
+			"phoneNumber": "+9998887777",
 			"simNumber": 1,
 			"deliveredAt": "2026-02-18T02:10:00.000+07:00"
 		},
@@ -241,11 +228,8 @@ func TestDecode_SMSDelivered(t *testing.T) {
 	if got.Payload.MessageID != "msg-789" {
 		t.Errorf("MessageID = %q, want msg-789", got.Payload.MessageID)
 	}
-	if got.Payload.Sender != "+1234567890" {
-		t.Errorf("Sender = %q, want +1234567890", got.Payload.Sender)
-	}
-	if got.Payload.Recipient != "+9998887777" {
-		t.Errorf("Recipient = %q, want +9998887777", got.Payload.Recipient)
+	if got.Payload.PhoneNumber != "+9998887777" {
+		t.Errorf("PhoneNumber = %q, want +9998887777", got.Payload.PhoneNumber)
 	}
 	if got.Payload.SimNumber != 1 {
 		t.Errorf("SimNumber = %d, want 1", got.Payload.SimNumber)
@@ -263,8 +247,7 @@ func TestDecode_SMSFailed(t *testing.T) {
 		"id": "Ey6ECgOkVVFjz3CL48B8C",
 		"payload": {
 			"messageId": "msg-000",
-			"sender": "+1234567890",
-			"recipient": "+4445556666",
+			"phoneNumber": "+4445556666",
 			"simNumber": 3,
 			"failedAt": "2026-02-18T02:15:00.000+07:00",
 			"reason": "Network error"
@@ -282,11 +265,8 @@ func TestDecode_SMSFailed(t *testing.T) {
 	if got.Payload.MessageID != "msg-000" {
 		t.Errorf("MessageID = %q, want msg-000", got.Payload.MessageID)
 	}
-	if got.Payload.Sender != "+1234567890" {
-		t.Errorf("Sender = %q, want +1234567890", got.Payload.Sender)
-	}
-	if got.Payload.Recipient != "+4445556666" {
-		t.Errorf("Recipient = %q, want +4445556666", got.Payload.Recipient)
+	if got.Payload.PhoneNumber != "+4445556666" {
+		t.Errorf("PhoneNumber = %q, want +4445556666", got.Payload.PhoneNumber)
 	}
 	if got.Payload.SimNumber != 3 {
 		t.Errorf("SimNumber = %d, want 3", got.Payload.SimNumber)


### PR DESCRIPTION
The normal documentation is incorrect, but the skill appears to be correct.

`recipient` and `sender` don't exist. `phoneNumber` does.