### PR TITLE
fix(auth/csvauth): deadlock in Authenticate on token flows

### DIFF
--- a/auth/csvauth/csvauth_test.go
+++ b/auth/csvauth/csvauth_test.go
@@ -5,7 +5,59 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestAuthenticateTokenNoDeadlock guards against the v1.2.4 regression where
+// Authenticate held a.mux via defer and then called loadAndVerifyToken, which
+// also tried to acquire a.mux — causing a deadlock on all token auth requests.
+func TestAuthenticateTokenNoDeadlock(t *testing.T) {
+	var key [16]byte
+	a := New(key[:])
+
+	const secret = "supersecrettoken"
+	c := a.NewCredential(PurposeToken, "ci-bot", secret, []string{"plain"}, []string{"deploy"}, "")
+	if err := a.CacheCredential(*c); err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		p   any
+		err error
+	}
+
+	// Authenticate("", token) — the token-as-password form
+	ch := make(chan result, 1)
+	go func() {
+		p, err := a.Authenticate("", secret)
+		ch <- result{p, err}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			t.Fatalf("Authenticate(\"\", token): unexpected error: %v", r.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Authenticate deadlocked — mutex was not released before calling loadAndVerifyToken")
+	}
+
+	// Authenticate("api", token) — the named-token-username form
+	ch2 := make(chan result, 1)
+	go func() {
+		p, err := a.Authenticate("api", secret)
+		ch2 <- result{p, err}
+	}()
+
+	select {
+	case r := <-ch2:
+		if r.err != nil {
+			t.Fatalf("Authenticate(\"api\", token): unexpected error: %v", r.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Authenticate deadlocked — mutex was not released before calling loadAndVerifyToken")
+	}
+}
 
 func TestCredentialCreationAndVerification(t *testing.T) {
 	type testCase struct {


### PR DESCRIPTION
## Bug

In v1.2.4, `Authenticate()` used `defer a.mux.Unlock()`, which held
the mutex for the entire function body. When a token credential was
presented, it would reach the `loadAndVerifyToken()` call at the
end — which also tries to `a.mux.Lock()` — causing a deadlock on
every token auth request.

```
Authenticate()
  a.mux.Lock()
  defer a.mux.Unlock()   ← still held here ↓
  ...
  loadAndVerifyToken()
    a.mux.Lock()         ← deadlock
```

The workaround was to call `LoadToken()` directly from calling code,
bypassing `Authenticate()` entirely for token flows.

## Fix

`ref(auth/csvauth): don't hold mutex longer than necessary` — replaces
`defer a.mux.Unlock()` with an explicit unlock immediately after the
map lookup, before the token path is reached.

## Test

`test(auth/csvauth): regression test for Authenticate token deadlock` —
`TestAuthenticateTokenNoDeadlock` exercises both the bare-token
(`"", token`) and named-username (`"api", token`) forms with a 1s
timeout, so a future regression fails fast rather than hanging the
suite.

## Checklist
- [x] Fix committed (`ref(auth/csvauth): don't hold mutex longer than necessary`)
- [x] Regression test added
- [x] Full test suite passes