### PR TITLE
feat(sql-migrate/v2): add sync subcommand

### DIFF
--- a/cmd/sql-migrate/main.go
+++ b/cmd/sql-migrate/main.go
@@ -87,6 +87,7 @@ EXAMPLE
    sql-migrate -d ./sql/migrations/ up 99
    sql-migrate -d ./sql/migrations/ down 1
    sql-migrate -d ./sql/migrations/ list
+   sql-migrate -d ./sql/migrations/ sync
 
 COMMANDS
    init          - creates migrations directory, initial migration, log file,
@@ -97,6 +98,7 @@ COMMANDS
    up [n]        - create a script to run pending migrations (ALL by default)
    down [n]      - create a script to roll back migrations (ONE by default)
    list          - lists migrations
+   sync          - create a script to refresh migrations.log from the DB
 
 OPTIONS
    -d <migrations directory>  default: ./sql/migrations/
@@ -184,7 +186,7 @@ func main() {
 		fsSub = flag.NewFlagSet("init", flag.ExitOnError)
 		fsSub.StringVar(&cfg.logPath, "migrations-log", "", fmt.Sprintf("migration log file (default: %s) relative to and saved in %s", defaultLogPath, M_MIGRATOR_NAME))
 		fsSub.StringVar(&cfg.sqlCommand, "sql-command", sqlCommandPSQL, "construct scripts with this to execute SQL files: 'psql', 'mysql', 'mariadb', or custom arguments")
-	case "create", "up", "down", "status", "list":
+	case "create", "up", "down", "status", "list", "sync":
 		fsSub = flag.NewFlagSet(subcmd, flag.ExitOnError)
 	default:
 		log.Printf("unknown command %s", subcmd)
@@ -355,6 +357,11 @@ func main() {
 		}
 
 		err = down(&state, downN)
+		if err != nil {
+			log.Fatal(err)
+		}
+	case "sync":
+		err = syncLog(&state)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -981,6 +988,21 @@ func down(state *State, n int) error {
 	fmt.Println("cat", filepathUnclean(state.LogPath))
 
 	showFixes(fixedUp, fixedDown)
+	return nil
+}
+
+func syncLog(state *State) error {
+	getMigsPath := filepath.Join(state.MigrationsDir, LOG_QUERY_NAME)
+	getMigsPath = filepathUnclean(getMigsPath)
+	getMigs := strings.Replace(state.SQLCommand, "%s", getMigsPath, 1)
+
+	logPath := filepathUnclean(state.LogPath)
+
+	fmt.Printf(shHeader)
+	fmt.Println("")
+	fmt.Println("# SYNC: reload migrations log from DB")
+	fmt.Println(getMigs + " > " + logPath + " || true")
+	fmt.Println("cat", logPath)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Adds a `sync` subcommand to `cmd/sql-migrate` (module `github.com/therootcompany/golib/cmd/sql-migrate/v2`)
- `sync` outputs a shell script that refreshes the local `migrations.log` by running `_migrations.sql` against the DB
- Uses `|| true` so a fresh DB with no `_migrations` table produces an empty log (all migrations pending) rather than a hard error

## Motivation

Before running `up` on a fresh environment — or after any out-of-band DB change — the local `migrations.log` may be stale or missing. Previously there was no built-in way to reload it; users had to construct the query command manually. `sync` closes that gap.

## Usage

```sh
sql-migrate -d ./db/migrations sync | sh
sql-migrate -d ./db/migrations up | sh
```

## Example output

```sh
#/bin/sh
set -e
set -u

if test -s ./.env; then
   . ./.env
fi

# SYNC: reload migrations log from DB
psql "$PG_URL" -v ON_ERROR_STOP=on -A -t --file ./db/migrations/_migrations.sql > ./db/migrations.log || true
cat ./db/migrations.log
```

## Changes

- `helpText`: added `sync` to the EXAMPLE and COMMANDS sections
- `main()` FlagSet switch: added `"sync"` to the `case "create", "up", "down", "status", "list"` branch
- `main()` subcommand switch: added `case "sync"` that calls `syncLog`
- New `syncLog(state *State) error` function (~15 lines): builds the `_migrations.sql` command, prints `shHeader`, prints the sync line with `|| true`, prints `cat <logPath>`

## Test plan

- [ ] `go build ./` passes in `cmd/sql-migrate/`
- [ ] `sql-migrate -d <dir> sync` produces a valid shell script with the `|| true` guard
- [ ] Running the generated script on a DB with no `_migrations` table produces an empty log (exit 0)
- [ ] Running the generated script on a DB with existing migrations populates the log correctly
- [ ] `sql-migrate sync | sh && sql-migrate up | sh` deploy sequence works end-to-end