### PR TITLE
feat(sql-migrate): add sync subcommand

### DIFF
--- a/cmd/sql-migrate/main.go
+++ b/cmd/sql-migrate/main.go
@@ -83,6 +83,7 @@ USAGE
 EXAMPLE
    sql-migrate -d ./sql/migrations/ init --sql-command <psql|mariadb|mysql>
    sql-migrate -d ./sql/migrations/ create <kebab-case-description>
+   sql-migrate -d ./sql/migrations/ sync
    sql-migrate -d ./sql/migrations/ status
    sql-migrate -d ./sql/migrations/ up 99
    sql-migrate -d ./sql/migrations/ down 1
@@ -93,6 +94,7 @@ COMMANDS
 	                and query for migrations
    create        - creates a new, canonically-named up/down file pair in the
                    migrations directory, with corresponding insert
+   sync          - create a script to reload migrations.log from the DB
    status        - shows the same output as if processing a forward-migration
    up [n]        - create a script to run pending migrations (ALL by default)
    down [n]      - create a script to roll back migrations (ONE by default)
@@ -184,7 +186,7 @@ func main() {
 		fsSub = flag.NewFlagSet("init", flag.ExitOnError)
 		fsSub.StringVar(&cfg.logPath, "migrations-log", "", fmt.Sprintf("migration log file (default: %s) relative to and saved in %s", defaultLogPath, M_MIGRATOR_NAME))
 		fsSub.StringVar(&cfg.sqlCommand, "sql-command", sqlCommandPSQL, "construct scripts with this to execute SQL files: 'psql', 'mysql', 'mariadb', or custom arguments")
-	case "create", "up", "down", "status", "list":
+	case "create", "sync", "up", "down", "status", "list":
 		fsSub = flag.NewFlagSet(subcmd, flag.ExitOnError)
 	default:
 		log.Printf("unknown command %s", subcmd)
@@ -275,6 +277,11 @@ func main() {
 	switch subcmd {
 	case "init":
 		break
+	case "sync":
+		if err := syncLog(&state); err != nil {
+			log.Fatal(err)
+		}
+		return
 	case "create":
 		if len(leafArgs) == 0 {
 			log.Fatal("create requires a description")
@@ -842,6 +849,20 @@ func fixupMigration(dir string, basename string) (up, down bool, warn error, err
 	}
 
 	return up, down, nil, nil
+}
+
+func syncLog(state *State) error {
+	getMigsPath := filepath.Join(state.MigrationsDir, LOG_QUERY_NAME)
+	getMigsPath = filepathUnclean(getMigsPath)
+	getMigs := strings.Replace(state.SQLCommand, "%s", getMigsPath, 1)
+	logPath := filepathUnclean(state.LogPath)
+
+	fmt.Printf(shHeader)
+	fmt.Println("")
+	fmt.Println("# SYNC: reload migrations log from DB")
+	fmt.Printf("%s > %s || true\n", getMigs, logPath)
+	fmt.Printf("cat %s\n", logPath)
+	return nil
 }
 
 func up(state *State, ups []string, n int) error {


### PR DESCRIPTION
Replaces #79

## Summary

- Adds a `sync` subcommand to `cmd/sql-migrate` (module `github.com/therootcompany/golib/cmd/sql-migrate/v2`)
- `sync` outputs a shell script that refreshes the local `migrations.log` by running `_migrations.sql` against the DB
- Uses `|| true` so a fresh DB with no `_migrations` table produces an empty log (all migrations pending) rather than a hard error

## Motivation

Before running `up` on a fresh environment — or after any out-of-band DB change — the local `migrations.log` may be stale or missing. Previously there was no built-in way to reload it; users had to construct the query command manually. `sync` closes that gap.

## Usage

```sh
sql-migrate -d ./db/migrations sync | sh
sql-migrate -d ./db/migrations up | sh
```

## Example output

```sh
#/bin/sh
set -e
set -u

if test -s ./.env; then
   . ./.env
fi

# SYNC: reload migrations log from DB
psql "$PG_URL" -v ON_ERROR_STOP=on -A -t --file ./db/migrations/_migrations.sql > ./db/migrations.log || true
cat ./db/migrations.log
```

## Changes

- `helpText`: added `sync` to the EXAMPLE and COMMANDS sections
- FlagSet switch: added `"sync"` to the `case "create", "sync", "up", "down", "status", "list"` branch
- Subcommand switch: added `case "sync"` that calls `syncLog`
- New `syncLog(state *State) error` function: builds the `_migrations.sql` command, prints `shHeader`, prints the sync line with `|| true`, prints `cat <logPath>`

## Test plan

- [ ] `go build .` passes in `cmd/sql-migrate/`
- [ ] `sql-migrate -d <dir> sync` produces a valid shell script with the `|| true` guard
- [ ] Running the generated script on a DB with no `_migrations` table produces an empty log (exit 0)
- [ ] Running the generated script on a DB with existing migrations populates the log correctly
- [ ] `sql-migrate sync | sh && sql-migrate up | sh` deploy sequence works end-to-end