### PR TITLE
fix(auth/csvauth): ID() returns Name only, not Name~hashID for tokens

### DIFF
--- a/auth/csvauth/credential.go
+++ b/auth/csvauth/credential.go
@@ -57,9 +57,6 @@ type Credential struct {
 }
 
 func (c *Credential) ID() string {
-	if c.Purpose == PurposeToken {
-		return c.Name + hashIDSep + c.hashID
-	}
 	return c.Name
 }
 


### PR DESCRIPTION
## Summary

- `Credential.ID()` for token rows previously returned `Name~hashID`, leaking the internal cache fingerprint to callers
- `hashID` is an internal lookup key only — it should never appear in JWTs, audit logs, or session records
- Fixed to always return `c.Name` for all credential types

## Side effects analysis

- `hashID` is only used internally in cache maps (`a.tokens[c.hashID]`, `nameCacheID`) — none of those use `ID()`
- TSV serialization writes `Name~hashID` directly (not via `ID()`) — unaffected
- No caller inside csvauth calls `ID()` — zero internal impact
- Callers that stored `principal.ID()` in JWTs/logs will now get the clean name

## Test plan

- [ ] Existing csvauth tests pass (`go test ./...`)
- [ ] Token auth still works (lookup is by `hashID` directly, not `ID()`)