### PR TITLE
fix(auth/csvauth): ID() returns Name only, not Name~hashID for tokens

### DIFF
--- a/auth/csvauth/credential.go
+++ b/auth/csvauth/credential.go
@@ -57,9 +57,6 @@ type Credential struct {
 }
 
 func (c *Credential) ID() string {
-	if c.Purpose == PurposeToken {
-		return c.Name + hashIDSep + c.hashID
-	}
 	return c.Name
 }
 


### PR DESCRIPTION
## Summary

- `Credential.ID()` now returns `c.Name` only, for all credential types
- Removes the `~hashID` suffix that was leaking an internal cache fingerprint into the public principal identity

## Why

Principal identity represents the subject (who), not the credential instance (which token). The `hashID` is an internal fingerprint used to distinguish token cache entries — it has no meaning to callers of `ID()`. Leaking it caused `act.sub` in impersonation JWTs to contain `operator:authd-operator~NrVu5YSK` instead of `operator:authd-operator`.

## Impact

- `ToRecord()` is unchanged — TSV round-trips correctly (still writes `Name~hashID` when `hashID` is set)
- `hashID` is only used internally in token cache maps; no external callers use `ID()` to reconstruct it
- All tests pass

Closes #130