### PR TITLE
fix(sql-migrate): strip id\t prefix when parsing migrations.log

### DIFF
--- a/cmd/sql-migrate/main.go
+++ b/cmd/sql-migrate/main.go
@@ -749,8 +749,20 @@ func (state *State) parseAndFixupBatches(text string) error {
 	state.Lines = strings.Split(text, "\n")
 	for i := range state.Lines {
 		line := strings.TrimSpace(state.Lines[i])
-		migration := commentStartRe.ReplaceAllString(line, "")
+		migration := line
+		// strip comments (before tab-split so trailing comments on data lines are handled)
+		migration = commentStartRe.ReplaceAllString(migration, "")
 		migration = strings.TrimSpace(migration)
+		// strip leading id\t prefix from new log format (id<tab>name)
+		// ignore any additional tab-delimited fields for future-proofing
+		parts := strings.Split(migration, "\t")
+		if len(parts) >= 2 {
+			migration = parts[1]
+		} else if len(parts) == 1 {
+			migration = parts[0]
+		} else {
+			continue
+		}
 		if migration != "" {
 			up, down, warn, err := fixupMigration(state.MigrationsDir, migration)
 			if warn != nil {


### PR DESCRIPTION
## Problem

`sql-migrate up` and `sql-migrate sync` fail when migrations.log uses the new tab-separated format (`id\tname`).

Error:
```
failed (up): open sql/migrations/05aba66a\t2026-06-03-003000_team-create.up.sql: no such file or directory
```

## Root Cause

`parseAndFixupBatches()` in main.go reads migrations.log and treats every line as a migration name. With the new log format that includes the 8-char hex ID (`id\tname`), the entire line including the ``id\t`` prefix was used as the filename, causing file-not-found errors.

## Fix

Split on tab-delimited fields and take only the second field (the migration name), ignoring any additional fields for future-proofing. This matches the same logic already used by ``shmigrate.Applied()``, ensuring both the old name-only format and the new ``id\tname`` format are parsed correctly.